### PR TITLE
Accept passed in max buffer size and lib version to 0.5.3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const main = async () => {
   const repoOwner = context.repo.owner;
   const githubToken = core.getInput('github-token');
   const testCommand = core.getInput('test-command') || 'npx jest';
+  const maxBuffer = core.getInput("max-buffer") || 1024 * 1024;
   const prNumber = context.issue.number;
   const githubClient = new GitHub(githubToken);
 
@@ -47,9 +48,11 @@ const main = async () => {
 
   const commentId = existingComment && existingComment.id;
 
-  const codeCoverage = execSync(testCommand).toString();
+  const execOptions = { maxBuffer };
+  const codeCoverage = execSync(testCommand, execOptions).toString();
   let coveragePercentage = execSync(
-    "npx coverage-percentage ./coverage/lcov.info --lcov"
+    "npx coverage-percentage ./coverage/lcov.info --lcov",
+    execOptions
   ).toString();
   coveragePercentage = parseFloat(coveragePercentage).toFixed(2);
   const commentBody = `${commentTitle}${coveragePercentage}</code></p>`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-reporter-action",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Comments a pull request with the jest code coverage",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
By default `execSync` will have a limited buffer size (200 KB) and there is no way to bump it when it's exceeded.
This PR introduces `max-buffer` option (by default will be 1MB)